### PR TITLE
Interface entre FormInputs e Filtro

### DIFF
--- a/Lib/Zion/Form/FilterableInput.php
+++ b/Lib/Zion/Form/FilterableInput.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ *
+ *    Sappiens Framework
+ *    Copyright (C) 2014, BRA Consultoria
+ *
+ *    Website do autor: www.braconsultoria.com.br/sappiens
+ *    Email do autor: sappiens@braconsultoria.com.br
+ *
+ *    Website do projeto, equipe e documentação: www.sappiens.com.br
+ *
+ *    Este programa é software livre; você pode redistribuí-lo e/ou
+ *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
+ *    publicada pela Free Software Foundation, versão 2.
+ *
+ *    Este programa é distribuído na expectativa de ser útil, mas SEM
+ *    QUALQUER GARANTIA; sem mesmo a garantia implícita de
+ *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
+ *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
+ *    detalhes.
+ *
+ *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
+ *    junto com este programa; se não, escreva para a Free Software
+ *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ *    02111-1307, USA.
+ *
+ *    Cópias da licença disponíveis em /Sappiens/_doc/licenca
+ *
+ */
+
+namespace Zion\Form;
+
+interface FilterableInput
+{
+    const EQUAL        = 'Equal';
+    const GREATER_THAN = 'GreaterThan';
+    const LESSER_THAN  = 'LesserThan';
+    const LIKE         = 'Like';
+
+    /**
+     * Retorna o tipo do filtro (EQUAL, GREATER_THAN, LESSER_THAN, LIKE...)
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro();
+
+    /**
+     * Seta o tipo de filtro de um input
+     *
+     * @return mixed
+     */
+    public function setCategoriaFiltro($categoria);
+}
+

--- a/Lib/Zion/Form/FormEscolha.php
+++ b/Lib/Zion/Form/FormEscolha.php
@@ -9,7 +9,7 @@
  *    Email do autor: sappiens@braconsultoria.com.br
  *
  *    Website do projeto, equipe e documentação: www.sappiens.com.br
- *   
+ *
  *    Este programa é software livre; você pode redistribuí-lo e/ou
  *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
  *    publicada pela Free Software Foundation, versão 2.
@@ -19,7 +19,7 @@
  *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
  *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
  *    detalhes.
- * 
+ *
  *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
  *    junto com este programa; se não, escreva para a Free Software
  *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -33,7 +33,7 @@ namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormEscolha extends \Zion\Form\FormBasico
+class FormEscolha extends \Zion\Form\FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -58,10 +58,11 @@ class FormEscolha extends \Zion\Form\FormBasico
     private $ignoreCod;
     private $callback;
     private $naoSelecionaveis;
+    private $categoriaFiltro;
 
     /**
      * FormEscolha::__construct()
-     * 
+     *
      * @param mixed $acao
      * @return
      */
@@ -79,11 +80,12 @@ class FormEscolha extends \Zion\Form\FormBasico
         $this->ordena = 'ASC';
         $this->inicio = 'Selecione...';
         $this->instrucoes = [];
+        $this->categoriaFiltro = FilterableInput::EQUAL;
     }
 
     /**
      * FormEscolha::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -93,7 +95,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -154,7 +156,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getMultiplo()
-     * 
+     *
      * @return
      */
     public function getMultiplo()
@@ -164,7 +166,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setMultiplo()
-     * 
+     *
      * @param mixed $multiplo
      * @return
      */
@@ -180,7 +182,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getExpandido()
-     * 
+     *
      * @return
      */
     public function getExpandido()
@@ -190,7 +192,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setExpandido()
-     * 
+     *
      * @param mixed $expandido
      * @return
      */
@@ -216,7 +218,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getOrdena()
-     * 
+     *
      * @return
      */
     public function getOrdena()
@@ -226,7 +228,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setOrdena()
-     * 
+     *
      * @param mixed $ordena
      * @return
      */
@@ -242,7 +244,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getArray()
-     * 
+     *
      * @return
      */
     public function getArray()
@@ -252,7 +254,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setArray()
-     * 
+     *
      * @param mixed $array
      * @return
      */
@@ -268,7 +270,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getInicio()
-     * 
+     *
      * @return
      */
     public function getInicio()
@@ -278,7 +280,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setInicio()
-     * 
+     *
      * @param mixed $inicio
      * @return
      */
@@ -294,7 +296,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getTabela()
-     * 
+     *
      * @return
      */
     public function getTabela()
@@ -304,7 +306,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setTabela()
-     * 
+     *
      * @param mixed $tabela
      * @return
      */
@@ -320,7 +322,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getCampoCod()
-     * 
+     *
      * @return
      */
     public function getCampoCod()
@@ -330,7 +332,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setCampoCod()
-     * 
+     *
      * @param mixed $campoCod
      * @return
      */
@@ -346,7 +348,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getCampoDesc()
-     * 
+     *
      * @return
      */
     public function getCampoDesc()
@@ -356,7 +358,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setCampoDesc()
-     * 
+     *
      * @param mixed $campoDesc
      * @return
      */
@@ -403,7 +405,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getSqlCompleto()
-     * 
+     *
      * @return
      */
     public function getSqlCompleto()
@@ -413,7 +415,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setSqlCompleto()
-     * 
+     *
      * @param mixed $sqlCompleto
      * @return
      */
@@ -429,7 +431,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getIdConexao()
-     * 
+     *
      * @return
      */
     public function getIdConexao()
@@ -439,7 +441,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setIdConexao()
-     * 
+     *
      * @param mixed $idConexao
      * @return
      */
@@ -455,7 +457,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql()
@@ -465,7 +467,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -530,7 +532,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setId()
-     * 
+     *
      * @param mixed $id
      * @return
      */
@@ -542,7 +544,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setNome()
-     * 
+     *
      * @param mixed $nome
      * @return
      */
@@ -554,7 +556,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setIdentifica()
-     * 
+     *
      * @param mixed $identifica
      * @return
      */
@@ -566,7 +568,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setValor()
-     * 
+     *
      * @param mixed $valor
      * @return
      */
@@ -578,7 +580,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setValorPadrao()
-     * 
+     *
      * @param mixed $valorPadrao
      * @return
      */
@@ -590,7 +592,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setDisabled()
-     * 
+     *
      * @param mixed $disabled
      * @return
      */
@@ -602,7 +604,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setComplemento()
-     * 
+     *
      * @param mixed $complemento
      * @return
      */
@@ -614,7 +616,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setAtributos()
-     * 
+     *
      * @param mixed $atributos
      * @return
      */
@@ -626,7 +628,7 @@ class FormEscolha extends \Zion\Form\FormBasico
 
     /**
      * FormEscolha::setClassCss()
-     * 
+     *
      * @param mixed $classCss
      * @return
      */
@@ -642,4 +644,25 @@ class FormEscolha extends \Zion\Form\FormBasico
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($categoria)
+    {
+        $this->categoriaFiltro = $categoria;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
+    }
 }

--- a/Lib/Zion/Form/FormInputCep.php
+++ b/Lib/Zion/Form/FormInputCep.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,18 +30,18 @@
 
 /**
  * \Zion\Form\FormInputCep()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputCep extends FormBasico
+class FormInputCep extends FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -51,10 +51,11 @@ class FormInputCep extends FormBasico
     private $minimoCaracteres;
     private $placeHolder;
     private $aliasSql;
+    private $categoriaFiltro;
 
     /**
      * FormInputCep::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
@@ -66,11 +67,12 @@ class FormInputCep extends FormBasico
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
         $this->setMaximoCaracteres(10);
+        $this->categoriaFiltro = FilterableInput::EQUAL;
     }
 
     /**
      * FormInputCep::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -80,7 +82,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -90,7 +92,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMaximoCaracteres($maximoCaracteres)
@@ -101,17 +103,17 @@ class FormInputCep extends FormBasico
                 throw new FormException("maximoCaracteres não pode ser menor que minimoCaracteres.");
             }
 
-            $this->maximoCaracteres = $maximoCaracteres;            
+            $this->maximoCaracteres = $maximoCaracteres;
         } else {
             throw new FormException("maximoCaracteres: Valor não numerico.");
         }
-        
+
         return $this;
     }
 
     /**
      * FormInputCep::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -121,7 +123,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMinimoCaracteres($minimoCaracteres)
@@ -132,17 +134,17 @@ class FormInputCep extends FormBasico
                 throw new FormException("minimoCaracteres não pode ser maior que maximoCaracteres.");
             }
 
-            $this->minimoCaracteres = $minimoCaracteres;            
+            $this->minimoCaracteres = $minimoCaracteres;
         } else {
             throw new FormException("minimoCaracteres: Valor não numerico.");
         }
-        
+
         return $this;
     }
 
     /**
      * FormInputCep::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
@@ -152,23 +154,23 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
     {
         if (is_bool($obrigatorio)) {
-            $this->obrigatorio = $obrigatorio;            
+            $this->obrigatorio = $obrigatorio;
         } else {
             throw new FormException("obrigatorio: Valor não booleano");
         }
-        
+
         return $this;
     }
 
     /**
      * FormInputCep::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
@@ -178,23 +180,23 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
     {
         if (!empty($placeHolder)) {
-            $this->placeHolder = $placeHolder;       
+            $this->placeHolder = $placeHolder;
         } else {
             throw new FormException("placeHolder: Nenhum valor informado");
         }
-        
+
         return $this;
     }
 
     /**
      * FormInputCep::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -203,24 +205,24 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
     public function setAliasSql($aliasSql)
     {
         if (!is_null($aliasSql)) {
-            $this->aliasSql = $aliasSql;            
+            $this->aliasSql = $aliasSql;
         } else {
             throw new FormException("aliasSql: Nenhum valor informado");
         }
-        
+
         return $this;
     }
 
     /**
      * FormInputCep::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -234,7 +236,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
@@ -245,7 +247,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -256,7 +258,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -267,7 +269,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
@@ -278,7 +280,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -289,7 +291,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -300,7 +302,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -311,7 +313,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -322,7 +324,7 @@ class FormInputCep extends FormBasico
 
     /**
      * FormInputCep::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -335,5 +337,27 @@ class FormInputCep extends FormBasico
     {
         parent::setContainer($container);
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($categoria)
+    {
+        $this->categoriaFiltro = $categoria;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
     }
 }

--- a/Lib/Zion/Form/FormInputCnpj.php
+++ b/Lib/Zion/Form/FormInputCnpj.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,18 +30,18 @@
 
 /**
  * \Zion\Form\FormInputCnpj()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputCnpj extends FormBasico
+class FormInputCnpj extends FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -52,10 +52,11 @@ class FormInputCnpj extends FormBasico
     private $placeHolder;
     private $aliasSql;
     private $mascara;
+    private $categoriaFiltro;
 
     /**
      * FormInputCnpj::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
@@ -67,11 +68,12 @@ class FormInputCnpj extends FormBasico
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
         $this->setMaximoCaracteres(18);
+        $this->categoriaFiltro = FilterableInput::EQUAL;
     }
 
     /**
      * FormInputCnpj::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -81,7 +83,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -91,7 +93,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -106,7 +108,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
@@ -131,7 +133,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCep::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -141,7 +143,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCep::setMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMinimoCaracteres($minimoCaracteres)
@@ -161,17 +163,17 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCep::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
     {
         return $this->minimoCaracteres;
     }
-    
+
     /**
      * FormInputCnpj::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -186,7 +188,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -196,7 +198,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -205,7 +207,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj:setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -221,7 +223,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCpf::setMascara()
-     * 
+     *
      * @param string $mascara
      *
      */
@@ -229,16 +231,16 @@ class FormInputCnpj extends FormBasico
     {
         $this->mascara = $mascara;
         return $this;
-    }    
+    }
 
     /**
      * FormInputCpf::getMascara()
-     * 
+     *
      * @return string
      */
     public function getMascara(){
         return $this->mascara;
-    }        
+    }
 
     /**
      * Sobrecarga de Metodos Básicos
@@ -246,7 +248,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
@@ -257,7 +259,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -268,7 +270,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -279,7 +281,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
@@ -290,7 +292,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -301,7 +303,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -312,7 +314,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -323,7 +325,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -334,7 +336,7 @@ class FormInputCnpj extends FormBasico
 
     /**
      * FormInputCnpj::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -342,11 +344,32 @@ class FormInputCnpj extends FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
+    }
 }

--- a/Lib/Zion/Form/FormInputCpf.php
+++ b/Lib/Zion/Form/FormInputCpf.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,18 +30,18 @@
 
 /**
  * \Zion\Form\FormInputCpf()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputCpf extends FormBasico
+class FormInputCpf extends FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -51,10 +51,11 @@ class FormInputCpf extends FormBasico
     private $minimoCaracteres;
     private $placeHolder;
     private $aliasSql;
+    private $categoriaFiltro;
 
     /**
      * FormInputCpf::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
@@ -66,11 +67,12 @@ class FormInputCpf extends FormBasico
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
         $this->setMaximoCaracteres(14);
+        $this->categoriaFiltro = FilterableInput::EQUAL;
     }
 
     /**
      * FormInputCpf::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -80,7 +82,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -90,7 +92,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -105,14 +107,14 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
     {
         return $this->obrigatorio;
     }
-    
+
     public function setMaximoCaracteres($maximoCaracteres)
     {
         if (is_numeric($maximoCaracteres)) {
@@ -130,7 +132,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCep::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -140,7 +142,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCep::setMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMinimoCaracteres($minimoCaracteres)
@@ -160,7 +162,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCep::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
@@ -170,7 +172,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -185,7 +187,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -195,7 +197,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -204,7 +206,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -224,7 +226,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
@@ -235,7 +237,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -246,7 +248,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -257,7 +259,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
@@ -268,7 +270,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -279,7 +281,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -290,7 +292,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -301,7 +303,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -312,7 +314,7 @@ class FormInputCpf extends FormBasico
 
     /**
      * FormInputCpf::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -320,11 +322,32 @@ class FormInputCpf extends FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
+    }
 }

--- a/Lib/Zion/Form/FormInputData.php
+++ b/Lib/Zion/Form/FormInputData.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,61 +30,63 @@
 
 /**
  * \Zion\Form\FormInputData()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 use Zion\Form\Exception\FormException as FormException;
 use Zion\Validacao\Data;
 
-class FormInputData extends \Zion\Form\FormBasico
+class FormInputData extends \Zion\Form\FormBasico implements FilterableInput
 {
     private $tipoBase;
-    private $acao; 
+    private $acao;
     private $obrigatorio;
     private $dataMinima;
     private $dataMaxima;
     private $placeHolder;
     private $aliasSql;
-    
+    private $categoriaFiltro;
+
     private $data;
-    
+
     /**
      * FormInputData::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
     {
         $this->tipoBase = 'data';
-        $this->acao = $acao;        
+        $this->acao = $acao;
         $this->mostrarSegundos = false;
-        
+
         $this->setNome($nome);
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
-        
+        $this->categoriaFiltro = FilterableInput::GREATER_THAN;
+
         $this->data = Data::instancia();
     }
-    
+
     /**
      * FormInputData::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
     {
         return $this->tipoBase;
     }
-    
+
     /**
      * FormInputData::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -94,7 +96,7 @@ class FormInputData extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setDataMinima()
-     * 
+     *
      * @return
      */
     public function setDataMinima($dataMinima)
@@ -105,27 +107,27 @@ class FormInputData extends \Zion\Form\FormBasico
                 throw new FormException("dataMinima não pode ser maior que dataMaxima.");
             }
 
-            $this->dataMinima = $dataMinima;        
+            $this->dataMinima = $dataMinima;
             return $this;
 
         } else {
             throw new FormException("dataMinima: O valor informado não é uma data/hora válida.");
         }
     }
-    
+
     /**
      * FormInputData::getDataMinima()
-     * 
+     *
      * @return
      */
     public function getDataMinima()
     {
         return $this->dataMinima;
     }
-    
+
     /**
      * FormInputData::setDataMaxima()
-     * 
+     *
      * @return
      */
     public function setDataMaxima($dataMaxima)
@@ -143,20 +145,20 @@ class FormInputData extends \Zion\Form\FormBasico
             throw new FormException("dataMaxima: O valor informado não é uma data/hora válida.");
         }
     }
-    
+
     /**
      * FormInputData::getDataMaxima()
-     * 
+     *
      * @return
      */
     public function getDataMaxima()
     {
         return $this->dataMaxima;
     }
-    
+
     /**
      * FormInputData::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -171,7 +173,7 @@ class FormInputData extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -181,7 +183,7 @@ class FormInputData extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -196,17 +198,17 @@ class FormInputData extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
     {
         return $this->obrigatorio;
     }
-    
+
     /**
      * FormInputData::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -215,7 +217,7 @@ class FormInputData extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -235,18 +237,18 @@ class FormInputData extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
     {
-        parent::setId($id);        
+        parent::setId($id);
         return $this;
     }
-    
+
     /**
      * FormInputData::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -254,10 +256,10 @@ class FormInputData extends \Zion\Form\FormBasico
         parent::setNome($nome);
         return $this;
     }
-    
+
     /**
      * FormInputData::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -265,28 +267,28 @@ class FormInputData extends \Zion\Form\FormBasico
         parent::setIdentifica($identifica);
         return $this;
     }
-    
+
     /**
      * FormInputData::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
-    {              
+    {
         parent::setValor($valor);
         return $this;
     }
-    
+
     public function getValor()
-    {              
+    {
         $valor = $this->data->converteData(parent::getValor());
-        
+
         return $valor;
     }
-    
+
     /**
      * FormInputData::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -294,10 +296,10 @@ class FormInputData extends \Zion\Form\FormBasico
         parent::setValorPadrao($valorPadrao);
         return $this;
     }
-    
+
     /**
      * FormInputData::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -305,10 +307,10 @@ class FormInputData extends \Zion\Form\FormBasico
         parent::setDisabled($disabled);
         return $this;
     }
-    
+
     /**
      * FormInputData::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -319,7 +321,7 @@ class FormInputData extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -327,10 +329,10 @@ class FormInputData extends \Zion\Form\FormBasico
         parent::setAtributos($atributos);
         return $this;
     }
-    
+
     /**
      * FormInputData::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -338,10 +340,32 @@ class FormInputData extends \Zion\Form\FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoria = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoria;
     }
 }

--- a/Lib/Zion/Form/FormInputDataHora.php
+++ b/Lib/Zion/Form/FormInputDataHora.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -27,50 +27,52 @@
 *    Cópias da licença disponíveis em /Sappiens/_doc/licenca
 *
 */
- 
+
 namespace Zion\Form;
 use Zion\Form\Exception\FormException as FormException;
 use Zion\Validacao\Data;
 
-class FormInputDataHora extends \Zion\Form\FormBasico
+class FormInputDataHora extends \Zion\Form\FormBasico implements FilterableInput
 {
     private $tipoBase;
-    private $acao; 
+    private $acao;
     private $obrigatorio;
     private $dataHoraMinima;
     private $dataHoraMaxima;
     private $placeHolder;
     private $aliasSql;
-    
+    private $categoriaFiltro;
+
     private $data;
-    
+
     public function __construct($acao, $nome, $identifica, $obrigatorio)
     {
         $this->tipoBase = 'dataHora';
-        $this->acao = $acao;        
+        $this->acao = $acao;
         $this->mostrarSegundos = false;
-        
+
         $this->setNome($nome);
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
-        
+        $this->categoriaFiltro = FilterableInput::GREATER_THAN;
+
         $this->data = Data::instancia();
     }
-    
+
     /**
      * FormInputData::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
     {
         return $this->tipoBase;
     }
-    
+
     /**
      * FormInputData::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -80,7 +82,7 @@ class FormInputDataHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setDataHoraMinima()
-     * 
+     *
      * @return
      */
     public function setDataHoraMinima($dataHoraMinima)
@@ -91,27 +93,27 @@ class FormInputDataHora extends \Zion\Form\FormBasico
                 throw new FormException("dataHoraMinima não pode ser maior que dataHoraMaxima.");
             }
 
-            $this->dataHoraMinima = $dataHoraMinima;        
+            $this->dataHoraMinima = $dataHoraMinima;
             return $this;
 
         } else {
             throw new FormException("dataHoraMinima: O valor informado não é uma data/hora válida.");
         }
     }
-    
+
     /**
      * FormInputData::getDataHoraMinima()
-     * 
+     *
      * @return
      */
     public function getDataHoraMinima()
     {
         return $this->dataHoraMinima;
     }
-    
+
     /**
      * FormInputData::setDataHoraMaxima()
-     * 
+     *
      * @return
      */
     public function setDataHoraMaxima($dataHoraMaxima)
@@ -129,20 +131,20 @@ class FormInputDataHora extends \Zion\Form\FormBasico
             throw new FormException("dataHoraMaxima: O valor informado não é uma data/hora válida.");
         }
     }
-    
+
     /**
      * FormInputData::getDataHoraMaxima()
-     * 
+     *
      * @return
      */
     public function getDataHoraMaxima()
     {
         return $this->dataHoraMaxima;
     }
-    
+
     /**
      * FormInputData::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -157,7 +159,7 @@ class FormInputDataHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -167,7 +169,7 @@ class FormInputDataHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -182,17 +184,17 @@ class FormInputDataHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
     {
         return $this->obrigatorio;
     }
-    
+
     /**
      * FormInputData::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -201,7 +203,7 @@ class FormInputDataHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -221,18 +223,18 @@ class FormInputDataHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
     {
-        parent::setId($id);        
+        parent::setId($id);
         return $this;
     }
-    
+
     /**
      * FormInputData::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -240,10 +242,10 @@ class FormInputDataHora extends \Zion\Form\FormBasico
         parent::setNome($nome);
         return $this;
     }
-    
+
     /**
      * FormInputData::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -251,28 +253,28 @@ class FormInputDataHora extends \Zion\Form\FormBasico
         parent::setIdentifica($identifica);
         return $this;
     }
-    
+
     /**
      * FormInputData::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
-    {              
+    {
         parent::setValor($valor);
         return $this;
     }
-    
+
     public function getValor()
-    {              
+    {
         $valor = $this->data->converteDataHora(parent::getValor());
-        
+
         return $valor;
     }
-    
+
     /**
      * FormInputData::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -280,10 +282,10 @@ class FormInputDataHora extends \Zion\Form\FormBasico
         parent::setValorPadrao($valorPadrao);
         return $this;
     }
-    
+
     /**
      * FormInputData::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -291,10 +293,10 @@ class FormInputDataHora extends \Zion\Form\FormBasico
         parent::setDisabled($disabled);
         return $this;
     }
-    
+
     /**
      * FormInputData::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -305,7 +307,7 @@ class FormInputDataHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputData::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -313,10 +315,10 @@ class FormInputDataHora extends \Zion\Form\FormBasico
         parent::setAtributos($atributos);
         return $this;
     }
-    
+
     /**
      * FormInputData::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -324,10 +326,32 @@ class FormInputDataHora extends \Zion\Form\FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
     }
 }

--- a/Lib/Zion/Form/FormInputEmail.php
+++ b/Lib/Zion/Form/FormInputEmail.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,7 +30,7 @@
 
 /**
  * \Zion\Form\FormInputEmail()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
@@ -41,7 +41,7 @@ namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputEmail extends FormBasico
+class FormInputEmail extends FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -51,10 +51,11 @@ class FormInputEmail extends FormBasico
     private $minimoCaracteres;
     private $placeHolder;
     private $aliasSql;
+    private $categoriaFiltro;
 
     /**
      * FormInputEmail::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
@@ -65,11 +66,12 @@ class FormInputEmail extends FormBasico
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
+        $this->categoriaFiltro = FilterableInput::EQUAL;
     }
 
     /**
      * FormInputEmail::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -79,7 +81,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -89,7 +91,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMaximoCaracteres($maximoCaracteres)
@@ -109,7 +111,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -119,7 +121,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMinimoCaracteres($minimoCaracteres)
@@ -139,7 +141,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
@@ -149,7 +151,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -164,7 +166,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
@@ -174,7 +176,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -189,17 +191,17 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
     {
         return $this->placeHolder;
     }
-    
+
     /**
      * FormInputEmail::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -208,7 +210,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -228,7 +230,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
@@ -239,7 +241,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -250,7 +252,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -261,7 +263,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
@@ -272,7 +274,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -283,7 +285,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -294,7 +296,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -305,7 +307,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -316,7 +318,7 @@ class FormInputEmail extends FormBasico
 
     /**
      * FormInputEmail::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -324,11 +326,32 @@ class FormInputEmail extends FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
+    }
 }

--- a/Lib/Zion/Form/FormInputFloat.php
+++ b/Lib/Zion/Form/FormInputFloat.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,23 +30,23 @@
 
 /**
  * \Zion\Form\FormInputFloat()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 
 use Zion\Form\Exception\FormException;
 use Zion\Validacao\Numero;
 use Zion\Form\FormBasico;
 
-class FormInputFloat extends FormBasico
+class FormInputFloat extends FormBasico implements FilterableInput
 {
     private $tipoBase;
-    private $acao; 
+    private $acao;
     private $largura;
     private $obrigatorio;
     private $valorMaximo;
@@ -54,12 +54,13 @@ class FormInputFloat extends FormBasico
     private $prefixo;
     private $placeHolder;
     private $aliasSql;
+    private $categoriaFiltro;
 
     private $numero;
-    
+
     /**
      * FormInputFloat::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
@@ -70,33 +71,34 @@ class FormInputFloat extends FormBasico
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
-        
+        $this->categoriaFiltro = FilterableInput::EQUAL;
+
         $this->numero = Numero::instancia();
     }
-    
+
     /**
      * FormInputFloat::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
     {
         return $this->tipoBase;
     }
-    
+
     /**
      * FormInputFloat::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
     {
         return $this->acao;
     }
-    
+
     /**
      * FormInputFloat::setLargura()
-     * 
+     *
      * @return
      */
     public function setLargura($largura)
@@ -111,17 +113,17 @@ class FormInputFloat extends FormBasico
 
     /**
      * FormInputFloat::getLargura()
-     * 
+     *
      * @return
      */
     public function getLargura()
     {
         return $this->largura;
     }
-    
+
     /**
      * FormInputFloat::setValorMaximo()
-     * 
+     *
      * @return
      */
     public function setValorMaximo($valorMaximo)
@@ -138,20 +140,20 @@ class FormInputFloat extends FormBasico
             throw new FormException("valorMaximo: O valor informado não é float.");
         }
     }
-    
+
     /**
      * FormInputFloat::getValorMaximo()
-     * 
+     *
      * @return
      */
     public function getValorMaximo()
     {
         return $this->valorMaximo;
     }
-    
+
     /**
      * FormInputFloat::setValorMinimo()
-     * 
+     *
      * @return
      */
     public function setValorMinimo($valorMinimo)
@@ -168,20 +170,20 @@ class FormInputFloat extends FormBasico
             throw new FormException("valorMinimo: O valor informado não é float.");
         }
     }
-    
+
     /**
      * FormInputFloat::getValorMinimo()
-     * 
+     *
      * @return
      */
     public function getValorMinimo()
     {
         return $this->valorMinimo;
     }
-    
+
     /**
      * FormInputFloat::setPrefixo()
-     * 
+     *
      * @return
      */
     public function setPrefixo($prefixo)
@@ -193,20 +195,20 @@ class FormInputFloat extends FormBasico
             throw new FormException("prefixo: Nenhum valor informado.");
         }
     }
-    
+
     /**
      * FormInputFloat::getPrefixo()
-     * 
+     *
      * @return
      */
     public function getPrefixo()
     {
         return $this->prefixo;
     }
-    
+
     /**
      * FormInputFloat::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -221,17 +223,17 @@ class FormInputFloat extends FormBasico
 
     /**
      * FormInputFloat::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
     {
         return $this->obrigatorio;
     }
-    
+
     /**
      * FormInputFloat::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -246,7 +248,7 @@ class FormInputFloat extends FormBasico
 
     /**
      * FormInputFloat::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -256,7 +258,7 @@ class FormInputFloat extends FormBasico
 
     /**
      * FormInputFloat::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -272,7 +274,7 @@ class FormInputFloat extends FormBasico
 
     /**
      * FormInputFloat::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -285,18 +287,18 @@ class FormInputFloat extends FormBasico
 
     /**
      * FormInputFloat::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
     {
-        parent::setId($id);        
+        parent::setId($id);
         return $this;
     }
-    
+
     /**
      * FormInputFloat::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -304,10 +306,10 @@ class FormInputFloat extends FormBasico
         parent::setNome($nome);
         return $this;
     }
-    
+
     /**
      * FormInputFloat::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -315,28 +317,28 @@ class FormInputFloat extends FormBasico
         parent::setIdentifica($identifica);
         return $this;
     }
-    
+
     /**
      * FormInputFloat::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
-    {              
+    {
         parent::setValor($valor);
         return $this;
     }
-    
+
     public function getValor()
-    {              
+    {
         $valor = parent::getValor();
-        
+
         return $valor ? $this->numero->floatCliente($valor) : $valor;
     }
-    
+
     /**
      * FormInputFloat::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -344,10 +346,10 @@ class FormInputFloat extends FormBasico
         parent::setValorPadrao($valorPadrao);
         return $this;
     }
-    
+
     /**
      * FormInputFloat::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -355,10 +357,10 @@ class FormInputFloat extends FormBasico
         parent::setDisabled($disabled);
         return $this;
     }
-    
+
     /**
      * FormInputFloat::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -369,7 +371,7 @@ class FormInputFloat extends FormBasico
 
     /**
      * FormInputFloat::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -377,10 +379,10 @@ class FormInputFloat extends FormBasico
         parent::setAtributos($atributos);
         return $this;
     }
-    
+
     /**
      * FormInputFloat::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -388,10 +390,32 @@ class FormInputFloat extends FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
     }
 }

--- a/Lib/Zion/Form/FormInputHora.php
+++ b/Lib/Zion/Form/FormInputHora.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,65 +30,67 @@
 
 /**
  * \Zion\Form\FormInputHora()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 use \Zion\Form\Exception\FormException as FormException;
 use \Zion\Validacao\Data as Data;
 
-class FormInputHora extends \Zion\Form\FormBasico
+class FormInputHora extends \Zion\Form\FormBasico implements FilterableInput
 {
    /**
     * @var mixed $tipoBase
     */
     private $tipoBase;
-    private $acao; 
+    private $acao;
     private $obrigatorio;
     private $horaMinima;
     private $horaMaxima;
     private $placeHolder;
     private $mostrarSegundos;
     private $aliasSql;
-    
+    private $categoriaFiltro;
+
     private $hora;
-    
+
     /**
      * FormInputHora::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
     {
         $this->tipoBase = 'hora';
-        $this->acao = $acao;        
+        $this->acao = $acao;
         $this->mostrarSegundos = false;
-        
+
         $this->setNome($nome);
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
-        
+        $this->categoriaFiltro = FilterableInput::GREATER_THAN;
+
         $this->hora = \Zion\Validacao\Data::instancia();
     }
-    
+
     /**
      * FormInputHora::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
     {
         return $this->tipoBase;
     }
-    
+
     /**
      * FormInputHora::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -98,7 +100,7 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::setHoraMinima()
-     * 
+     *
      * @return
      */
     public function setHoraMinima($horaMinima)
@@ -109,27 +111,27 @@ class FormInputHora extends \Zion\Form\FormBasico
                 throw new FormException("horaMinima não pode ser maior que horaMaxima.");
             }
 
-            $this->horaMinima = $horaMinima;        
+            $this->horaMinima = $horaMinima;
             return $this;
 
         } else {
             throw new FormException("horaMinima: O valor informado não é uma hora válida.");
         }
     }
-    
+
     /**
      * FormInputHora::getHoraMinima()
-     * 
+     *
      * @return
      */
     public function getHoraMinima()
     {
         return $this->horaMinima;
     }
-    
+
     /**
      * FormInputHora::setHoraMaxima()
-     * 
+     *
      * @return
      */
     public function setHoraMaxima($horaMaxima)
@@ -147,20 +149,20 @@ class FormInputHora extends \Zion\Form\FormBasico
             throw new FormException("horaMaxima: O valor informado não é uma hora válida.");
         }
     }
-    
+
     /**
      * FormInputHora::getHoraMaxima()
-     * 
+     *
      * @return
      */
     public function getHoraMaxima()
     {
         return $this->horaMaxima;
     }
-    
+
     /**
      * FormInputHora::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -175,7 +177,7 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -185,7 +187,7 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -200,17 +202,17 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
     {
         return $this->obrigatorio;
     }
-    
+
     /**
      * FormInputHora::setMostrarSegundos()
-     * 
+     *
      * @return
      */
     public function setMostrarSegundos($mostrarSegundos)
@@ -222,10 +224,10 @@ class FormInputHora extends \Zion\Form\FormBasico
             throw new FormException("mostrarSegundos: Valor não booleano");
         }
     }
-    
+
     /**
      * FormInputHora::getMostrarSegundos()
-     * 
+     *
      * @return
      */
     public function getMostrarSegundos()
@@ -235,7 +237,7 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -251,7 +253,7 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -264,18 +266,18 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
     {
-        parent::setId($id);        
+        parent::setId($id);
         return $this;
     }
-    
+
     /**
      * FormInputHora::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -283,10 +285,10 @@ class FormInputHora extends \Zion\Form\FormBasico
         parent::setNome($nome);
         return $this;
     }
-    
+
     /**
      * FormInputHora::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -294,21 +296,21 @@ class FormInputHora extends \Zion\Form\FormBasico
         parent::setIdentifica($identifica);
         return $this;
     }
-    
+
     /**
      * FormInputHora::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
-    {              
+    {
         parent::setValor($valor);
         return $this;
     }
-    
+
     /**
      * FormInputHora::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -316,10 +318,10 @@ class FormInputHora extends \Zion\Form\FormBasico
         parent::setValorPadrao($valorPadrao);
         return $this;
     }
-    
+
     /**
      * FormInputHora::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -327,10 +329,10 @@ class FormInputHora extends \Zion\Form\FormBasico
         parent::setDisabled($disabled);
         return $this;
     }
-    
+
     /**
      * FormInputHora::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -341,7 +343,7 @@ class FormInputHora extends \Zion\Form\FormBasico
 
     /**
      * FormInputHora::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -349,10 +351,10 @@ class FormInputHora extends \Zion\Form\FormBasico
         parent::setAtributos($atributos);
         return $this;
     }
-    
+
     /**
      * FormInputHora::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -360,10 +362,32 @@ class FormInputHora extends \Zion\Form\FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
     }
 }

--- a/Lib/Zion/Form/FormInputNumber.php
+++ b/Lib/Zion/Form/FormInputNumber.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,17 +30,17 @@
 
 /**
  * \Zion\Form\FormInputNumber()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputNumber extends \Zion\Form\FormBasico
+class FormInputNumber extends \Zion\Form\FormBasico implements FilterableInput
 {
     private $tipoBase;
     private $acao;
@@ -52,10 +52,11 @@ class FormInputNumber extends \Zion\Form\FormBasico
     private $valorMinimo;
     private $placeHolder;
     private $aliasSql;
-    
+    private $categoriaFiltro;
+
     /**
      * FormInputNumber::__construct()
-     * 
+     *
      * @return
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
@@ -66,31 +67,32 @@ class FormInputNumber extends \Zion\Form\FormBasico
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
+        $this->categoriaFiltro = FilterableInput::EQUAL;
     }
-    
+
     /**
      * FormInputNumber::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
     {
         return $this->tipoBase;
     }
-    
+
     /**
      * FormInputNumber::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
     {
         return $this->acao;
     }
-    
+
     /**
      * FormInputNumber::setLargura()
-     * 
+     *
      * @return
      */
     public function setLargura($largura)
@@ -105,17 +107,17 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::getLargura()
-     * 
+     *
      * @return
      */
     public function getLargura()
     {
         return $this->largura;
     }
-    
+
     /**
      * FormInputNumber::setMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMaximoCaracteres($maximoCaracteres)
@@ -135,7 +137,7 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -145,7 +147,7 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::setMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function setMinimoCaracteres($minimoCaracteres)
@@ -165,17 +167,17 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
     {
         return $this->minimoCaracteres;
     }
-    
+
     /**
      * FormInputNumber::setValorMinimo()
-     * 
+     *
      * @return
      */
     public function setValorMinimo($valorMinimo)
@@ -192,20 +194,20 @@ class FormInputNumber extends \Zion\Form\FormBasico
             throw new FormException("valorMinimo: Valor não numérico");
         }
     }
-    
+
     /**
      * FormInputNumber::getValorMinimo()
-     * 
+     *
      * @return
      */
     public function getValorMinimo()
     {
         return $this->valorMinimo;
     }
-    
+
     /**
      * FormInputNumber::setValorMaximo()
-     * 
+     *
      * @return
      */
     public function setValorMaximo($valorMaximo)
@@ -222,20 +224,20 @@ class FormInputNumber extends \Zion\Form\FormBasico
             throw new FormException("valorMaximo: Valor não numérico");
         }
     }
-    
+
     /**
      * FormInputNumber::getValorMaximo()
-     * 
+     *
      * @return
      */
     public function getValorMaximo()
     {
         return $this->valorMaximo;
     }
-    
+
     /**
      * FormInputNumber::setObrigarorio()
-     * 
+     *
      * @return
      */
     public function setObrigarorio($obrigatorio)
@@ -250,17 +252,17 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
     {
         return $this->obrigatorio;
     }
-    
+
     /**
      * FormInputNumber::setPlaceHolder()
-     * 
+     *
      * @return
      */
     public function setPlaceHolder($placeHolder)
@@ -275,17 +277,17 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
     {
         return $this->placeHolder;
     }
-    
+
     /**
      * FormInputNumber::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -301,31 +303,31 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
         return $this->aliasSql;
     }
-    
+
     /**
      * Sobrecarga de Metodos Básicos
      */
-     
+
     /**
      * FormInputNumber::setId()
-     * 
+     *
      * @return
      */
     public function setId($id)
     {
-        parent::setId($id);        
+        parent::setId($id);
         return $this;
     }
-    
+
     /**
      * FormInputNumber::setNome()
-     * 
+     *
      * @return
      */
     public function setNome($nome)
@@ -333,10 +335,10 @@ class FormInputNumber extends \Zion\Form\FormBasico
         parent::setNome($nome);
         return $this;
     }
-    
+
     /**
      * FormInputNumber::setIdentifica()
-     * 
+     *
      * @return
      */
     public function setIdentifica($identifica)
@@ -344,21 +346,21 @@ class FormInputNumber extends \Zion\Form\FormBasico
         parent::setIdentifica($identifica);
         return $this;
     }
-    
+
     /**
      * FormInputNumber::setValor()
-     * 
+     *
      * @return
      */
     public function setValor($valor)
-    {              
+    {
         parent::setValor($valor);
         return $this;
     }
-    
+
     /**
      * FormInputNumber::setValorPadrao()
-     * 
+     *
      * @return
      */
     public function setValorPadrao($valorPadrao)
@@ -366,10 +368,10 @@ class FormInputNumber extends \Zion\Form\FormBasico
         parent::setValorPadrao($valorPadrao);
         return $this;
     }
-    
+
     /**
      * FormInputNumber::setDisabled()
-     * 
+     *
      * @return
      */
     public function setDisabled($disabled)
@@ -377,10 +379,10 @@ class FormInputNumber extends \Zion\Form\FormBasico
         parent::setDisabled($disabled);
         return $this;
     }
-    
+
     /**
      * FormInputNumber::setComplemento()
-     * 
+     *
      * @return
      */
     public function setComplemento($complemento)
@@ -391,7 +393,7 @@ class FormInputNumber extends \Zion\Form\FormBasico
 
     /**
      * FormInputNumber::setAtributos()
-     * 
+     *
      * @return
      */
     public function setAtributos($atributos)
@@ -399,10 +401,10 @@ class FormInputNumber extends \Zion\Form\FormBasico
         parent::setAtributos($atributos);
         return $this;
     }
-    
+
     /**
      * FormInputNumber::setClassCss()
-     * 
+     *
      * @return
      */
     public function setClassCss($classCss)
@@ -410,10 +412,32 @@ class FormInputNumber extends \Zion\Form\FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
     }
 }

--- a/Lib/Zion/Form/FormInputTelefone.php
+++ b/Lib/Zion/Form/FormInputTelefone.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,7 +30,7 @@
 
 /**
  * \Zion\Form\FormInputTelefone()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
@@ -41,7 +41,7 @@ namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputTelefone extends FormBasico
+class FormInputTelefone extends FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -51,10 +51,11 @@ class FormInputTelefone extends FormBasico
     private $minimoCaracteres;
     private $placeHolder;
     private $aliasSql;
+    private $categoriaFiltro;
 
     /**
      * FormInputTelefone::__construct()
-     * 
+     *
      * @param mixed $acao
      * @param mixed $nome
      * @param mixed $identifica
@@ -69,11 +70,12 @@ class FormInputTelefone extends FormBasico
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
+        $this->categoriaFiltro = FilterableInput::EQUAL;
     }
 
     /**
      * FormInputTelefone::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -83,7 +85,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -93,7 +95,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setMaximoCaracteres()
-     * 
+     *
      * @param mixed $maximoCaracteres
      * @return
      */
@@ -114,7 +116,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -124,7 +126,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setMinimoCaracteres()
-     * 
+     *
      * @param mixed $minimoCaracteres
      * @return
      */
@@ -145,7 +147,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
@@ -155,7 +157,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setObrigarorio()
-     * 
+     *
      * @param mixed $obrigatorio
      * @return
      */
@@ -171,7 +173,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
@@ -181,7 +183,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setPlaceHolder()
-     * 
+     *
      * @param mixed $placeHolder
      * @return
      */
@@ -197,7 +199,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -207,7 +209,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -223,7 +225,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -236,7 +238,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setId()
-     * 
+     *
      * @param mixed $id
      * @return
      */
@@ -248,7 +250,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setNome()
-     * 
+     *
      * @param mixed $nome
      * @return
      */
@@ -260,7 +262,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setIdentifica()
-     * 
+     *
      * @param mixed $identifica
      * @return
      */
@@ -272,7 +274,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setValor()
-     * 
+     *
      * @param mixed $valor
      * @return
      */
@@ -284,7 +286,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setValorPadrao()
-     * 
+     *
      * @param mixed $valorPadrao
      * @return
      */
@@ -296,7 +298,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setDisabled()
-     * 
+     *
      * @param mixed $disabled
      * @return
      */
@@ -308,7 +310,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setComplemento()
-     * 
+     *
      * @param mixed $complemento
      * @return
      */
@@ -320,7 +322,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setAtributos()
-     * 
+     *
      * @param mixed $atributos
      * @return
      */
@@ -332,7 +334,7 @@ class FormInputTelefone extends FormBasico
 
     /**
      * FormInputTelefone::setClassCss()
-     * 
+     *
      * @param mixed $classCss
      * @return
      */
@@ -341,11 +343,32 @@ class FormInputTelefone extends FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
+    }
 }

--- a/Lib/Zion/Form/FormInputTextArea.php
+++ b/Lib/Zion/Form/FormInputTextArea.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,7 +30,7 @@
 
 /**
  * \Zion\Form\FormInputTextArea()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
@@ -41,7 +41,7 @@ namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputTextArea extends FormBasico
+class FormInputTextArea extends FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -55,10 +55,11 @@ class FormInputTextArea extends FormBasico
     private $colunas;
     private $linhas;
     private $form;
+    private $categoriaFiltro;
 
     /**
      * FormInputTextArea::__construct()
-     * 
+     *
      * @param mixed $acao
      * @param mixed $nome
      * @param mixed $identifica
@@ -73,11 +74,12 @@ class FormInputTextArea extends FormBasico
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
+        $this->categoriaFiltro = FilterableInput::LIKE;
     }
 
     /**
      * FormInputTextArea::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -87,7 +89,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -97,7 +99,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setMaximoCaracteres()
-     * 
+     *
      * @param mixed $maximoCaracteres
      * @return
      */
@@ -118,7 +120,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -128,7 +130,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setMinimoCaracteres()
-     * 
+     *
      * @param mixed $minimoCaracteres
      * @return
      */
@@ -149,7 +151,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
@@ -159,7 +161,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setObrigarorio()
-     * 
+     *
      * @param mixed $obrigatorio
      * @return
      */
@@ -175,7 +177,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
@@ -185,7 +187,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setPlaceHolder()
-     * 
+     *
      * @param mixed $placeHolder
      * @return
      */
@@ -201,7 +203,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -211,7 +213,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -227,7 +229,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql()
@@ -301,7 +303,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setId()
-     * 
+     *
      * @param mixed $id
      * @return
      */
@@ -313,7 +315,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setNome()
-     * 
+     *
      * @param mixed $nome
      * @return
      */
@@ -325,7 +327,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setIdentifica()
-     * 
+     *
      * @param mixed $identifica
      * @return
      */
@@ -337,7 +339,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setValor()
-     * 
+     *
      * @param mixed $valor
      * @return
      */
@@ -349,7 +351,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setValorPadrao()
-     * 
+     *
      * @param mixed $valorPadrao
      * @return
      */
@@ -361,7 +363,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setDisabled()
-     * 
+     *
      * @param mixed $disabled
      * @return
      */
@@ -373,7 +375,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setComplemento()
-     * 
+     *
      * @param mixed $complemento
      * @return
      */
@@ -385,7 +387,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setAtributos()
-     * 
+     *
      * @param mixed $atributos
      * @return
      */
@@ -397,7 +399,7 @@ class FormInputTextArea extends FormBasico
 
     /**
      * FormInputTextArea::setClassCss()
-     * 
+     *
      * @param mixed $classCss
      * @return
      */
@@ -406,17 +408,38 @@ class FormInputTextArea extends FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
     }
-    
+
     public function setNomeForm($nomeForm)
     {
         parent::setNomeForm($nomeForm);
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
+    }
 }

--- a/Lib/Zion/Form/FormInputTexto.php
+++ b/Lib/Zion/Form/FormInputTexto.php
@@ -8,7 +8,7 @@
 *    Email do autor: sappiens@braconsultoria.com.br
 *
 *    Website do projeto, equipe e documentação: www.sappiens.com.br
-*   
+*
 *    Este programa é software livre; você pode redistribuí-lo e/ou
 *    modificá-lo sob os termos da Licença Pública Geral GNU, conforme
 *    publicada pela Free Software Foundation, versão 2.
@@ -18,7 +18,7 @@
 *    COMERCIALIZAÇÃO ou de ADEQUAÇÃO A QUALQUER PROPÓSITO EM
 *    PARTICULAR. Consulte a Licença Pública Geral GNU para obter mais
 *    detalhes.
-* 
+*
 *    Você deve ter recebido uma cópia da Licença Pública Geral GNU
 *    junto com este programa; se não, escreva para a Free Software
 *    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
@@ -30,18 +30,18 @@
 
 /**
  * \Zion\Form\FormInputTexto()
- * 
+ *
  * @author The Sappiens Team
  * @copyright 2014
  * @version 2014
  * @access public
  */
- 
+
 namespace Zion\Form;
 
 use \Zion\Form\Exception\FormException as FormException;
 
-class FormInputTexto extends FormBasico
+class FormInputTexto extends FormBasico implements FilterableInput
 {
 
     private $tipoBase;
@@ -57,10 +57,11 @@ class FormInputTexto extends FormBasico
     private $autoComplete;
     private $deveSerIgualA;
     private $aliasSql;
+    private $categoriaFiltro;
 
     /**
      * FormInputTexto::__construct()
-     * 
+     *
      * @param mixed $acao
      * @param mixed $nome
      * @param mixed $identifica
@@ -69,7 +70,7 @@ class FormInputTexto extends FormBasico
      */
     public function __construct($acao, $nome, $identifica, $obrigatorio)
     {
-        $this->tipoBase = 'texto';        
+        $this->tipoBase = 'texto';
         $this->acao = $acao;
         $this->autoTrim = true;
         $this->converterHtml = true;
@@ -77,11 +78,12 @@ class FormInputTexto extends FormBasico
         $this->setId($nome);
         $this->setIdentifica($identifica);
         $this->setObrigarorio($obrigatorio);
+        $this->categoriaFiltro = FilterableInput::LIKE;
     }
 
     /**
      * FormInputTexto::getTipoBase()
-     * 
+     *
      * @return
      */
     public function getTipoBase()
@@ -91,7 +93,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getAcao()
-     * 
+     *
      * @return
      */
     public function getAcao()
@@ -101,7 +103,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setLargura()
-     * 
+     *
      * @param mixed $largura
      * @return
      */
@@ -117,7 +119,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getLargura()
-     * 
+     *
      * @return
      */
     public function getLargura()
@@ -127,7 +129,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setMaximoCaracteres()
-     * 
+     *
      * @param mixed $maximoCaracteres
      * @return
      */
@@ -148,7 +150,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getMaximoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMaximoCaracteres()
@@ -158,7 +160,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setMinimoCaracteres()
-     * 
+     *
      * @param mixed $minimoCaracteres
      * @return
      */
@@ -179,7 +181,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getMinimoCaracteres()
-     * 
+     *
      * @return
      */
     public function getMinimoCaracteres()
@@ -189,7 +191,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setCaixa()
-     * 
+     *
      * @param mixed $caixa
      * @return
      */
@@ -205,7 +207,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getCaixa()
-     * 
+     *
      * @return
      */
     public function getCaixa()
@@ -215,7 +217,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setObrigarorio()
-     * 
+     *
      * @param mixed $obrigatorio
      * @return
      */
@@ -231,7 +233,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getObrigatorio()
-     * 
+     *
      * @return
      */
     public function getObrigatorio()
@@ -241,7 +243,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setConverterHtml()
-     * 
+     *
      * @param mixed $converterHtml
      * @return
      */
@@ -257,7 +259,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getConverterHtml()
-     * 
+     *
      * @return
      */
     public function getConverterHtml()
@@ -267,7 +269,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setAutoTrim()
-     * 
+     *
      * @param mixed $autoTrim
      * @return
      */
@@ -283,7 +285,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getAutoTrim()
-     * 
+     *
      * @return
      */
     public function getAutoTrim()
@@ -293,7 +295,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setPlaceHolder()
-     * 
+     *
      * @param mixed $placeHolder
      * @return
      */
@@ -309,7 +311,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getPlaceHolder()
-     * 
+     *
      * @return
      */
     public function getPlaceHolder()
@@ -319,7 +321,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setAutoComplete()
-     * 
+     *
      * @param mixed $autoComplete
      * @return
      */
@@ -335,7 +337,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getAutoComplete()
-     * 
+     *
      * @return
      */
     public function getAutoComplete()
@@ -345,7 +347,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setDeveSerIgualA()
-     * 
+     *
      * @param mixed $deveSerIgualA
      * @return
      */
@@ -361,7 +363,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getDeveSerIgualA()
-     * 
+     *
      * @return
      */
     public function getDeveSerIgualA()
@@ -371,7 +373,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setAliasSql()
-     * 
+     *
      * @param string $aliasSql
      *
      */
@@ -387,7 +389,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::getAliasSql()
-     * 
+     *
      * @return string
      */
     public function getAliasSql(){
@@ -400,7 +402,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setId()
-     * 
+     *
      * @param mixed $id
      * @return
      */
@@ -412,7 +414,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setNome()
-     * 
+     *
      * @param mixed $nome
      * @return
      */
@@ -424,7 +426,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setIdentifica()
-     * 
+     *
      * @param mixed $identifica
      * @return
      */
@@ -436,7 +438,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setValor()
-     * 
+     *
      * @param mixed $valor
      * @return
      */
@@ -448,7 +450,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setValorPadrao()
-     * 
+     *
      * @param mixed $valorPadrao
      * @return
      */
@@ -460,7 +462,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setDisabled()
-     * 
+     *
      * @param mixed $disabled
      * @return
      */
@@ -472,7 +474,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setComplemento()
-     * 
+     *
      * @param mixed $complemento
      * @return
      */
@@ -484,7 +486,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setAtributos()
-     * 
+     *
      * @param mixed $atributos
      * @return
      */
@@ -496,7 +498,7 @@ class FormInputTexto extends FormBasico
 
     /**
      * FormInputTexto::setClassCss()
-     * 
+     *
      * @param mixed $classCss
      * @return
      */
@@ -505,10 +507,32 @@ class FormInputTexto extends FormBasico
         parent::setClassCss($classCss);
         return $this;
     }
-    
+
     public function setContainer($container)
     {
         parent::setContainer($container);
         return $this;
-    }   
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return self
+     */
+    public function setCategoriaFiltro($tipo)
+    {
+        $this->categoriaFiltro = $tipo;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @return string
+     */
+    public function getCategoriaFiltro()
+    {
+        return $this->categoriaFiltro;
+    }
 }


### PR DESCRIPTION
Esse PR introduz a interface `FilterableInput` que é consumida pelo
componente de Filtro que está no pacote da Potencia. Essa interface
implementa dois métodos simples:
- `getCategoriaFiltro`
- `setCategoriaFiltro`

A propriedade categoriaFiltro dirá ao filtro como as expressões serão
montadas no `Doctrine\DBAL\Query\QueryBuilder`.

Até o momento, temos 4 categorias, são elas:
- `EqualFilterInput`, que compara por igualdade;
- `LikeFilterInput`, que faz uso o operador `LIKE` para realizar a condição;
- `GreaterThan`, que utiliza o operador `>=` para suas comparações;
- `LesserThan`, que faz uso do `<=;`

Este PR também já implementa essa interface em vários `Inputs` relevantes,
mas pode ser facilmente implementado para outros posteriormente.
